### PR TITLE
Changed collection structure

### DIFF
--- a/catpol/pipelines/mongo.py
+++ b/catpol/pipelines/mongo.py
@@ -9,17 +9,14 @@ class MongoDBPipeline(object):
         logger = logging.getLogger(__name__)
         self.collection = None
         self.collection_item_branch = dict()
-        self.collection_item_branch_obj_id = dict()
         if 'MONGODB_URI' in settings:
             conn = pymongo.MongoClient(settings['MONGODB_URI'])
             db = conn.get_default_database()
             if 'MONGODB_COLLECTION' in settings:
                 self.collection = db[settings['MONGODB_COLLECTION']]
-                self.obj_id = self.collection.insert({'documents': []})
             if 'MONGODB_COLLECTION_ITEM_BRANCH' in settings:
                 for (item_type, collection) in settings['MONGODB_COLLECTION_ITEM_BRANCH'].items():
                     self.collection_item_branch[item_type] = db[collection]
-                    self.collection_item_branch_obj_id[item_type] = self.collection_item_branch[item_type].insert({'documents': []})
 
     def process_item(self, item, spider):
         d = dict(item)
@@ -29,18 +26,13 @@ class MongoDBPipeline(object):
             item_type = item_type[:-4]
         item_type = item_type.lower()
         collection = None
-        obj_id = 0
         if item_type in self.collection_item_branch:
             collection = self.collection_item_branch[item_type]
-            obj_id = self.collection_item_branch_obj_id[item_type]
         elif self.collection:
             collection = self.collection
-            obj_id = self.obj_id
             d['type'] = item_type
         if collection:
-            collection.update(
-                {'_id': obj_id},
-                {'$push': {'documents': d}})
+            collection.insert(d)
             logger = logging.getLogger(__name__)
             logger.debug('Added \'{}\' item to mongo database'.format(item_type))
         return item


### PR DESCRIPTION
The old structure had the problem that documents we becoming too large, and the MongoDB documents are limited to 16 megabytes (a very small limit for the size of our data).

As discussed with @razvanpavel, documents are going to be inserted in the top level of the collection from now on.

The problem is now that we need to distinguish between different runs of the spiders, but this shall be discussed at a later time.