### PR TITLE
Added profile picture extraction

### DIFF
--- a/catpol/items/personal_data.py
+++ b/catpol/items/personal_data.py
@@ -9,3 +9,4 @@ class PersonalDataItem(scrapy.Item):
     eurogroup = scrapy.Field()
     birthplace = scrapy.Field()
     party = scrapy.Field()
+    picture = scrapy.Field()

--- a/catpol/spiders/cdep.py
+++ b/catpol/spiders/cdep.py
@@ -48,6 +48,12 @@ class Cdep(scrapy.Spider):
             'div.profile-dep div.boxTitle h1::text'
         ).extract_first()
 
+        # parse profile picture src
+        profile_picture_src = response.urljoin(
+                response.css(
+                    'div.profile-dep div.profile-pic-dep img::attr(src)'
+                ).extract_first())
+
         # parse birthdate
         birthdate = ''.join(response.css('div.profile-dep div.profile-pic-dep::text').extract()).strip()
 
@@ -69,6 +75,7 @@ class Cdep(scrapy.Spider):
         personal_data_loader.add_value('name', person_name)
         personal_data_loader.add_value('birthdate', birthdate)
         personal_data_loader.add_value('url', response.url)
+        personal_data_loader.add_value('picture', profile_picture_src)
         yield personal_data_loader.load_item()
 
         # follow plenery speaking url


### PR DESCRIPTION
The _cdep_ spider show now extract profile pictures and store them in the _picture_ field of the person. 

Tests were ran, but we would also like to run a full crawl.—@razvanpavel

**Note: Higher resolutions are also available if you add `mari` before the filename in the URL—e.g. change from http://www.cdep.ro/parlamentari/l2016/Boboc_Tudorita2.JPG to http://www.cdep.ro/parlamentari/l2016/mari/Boboc_Tudorita2.JPG**.